### PR TITLE
Show README with sidebar TOC

### DIFF
--- a/index
+++ b/index
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
-</body>
-</html>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,16 @@
+---
+title: Home
+---
+
+<link rel="stylesheet" href="style.css">
+<script src="toc.js" defer></script>
+
+<nav id="toc">
+  <ul>
+    <li><a href="index.html">Home</a></li>
+  </ul>
+</nav>
+
+<main>
+{% include_relative README.md %}
+</main>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,38 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+main {
+    margin-left: 220px;
+    padding: 20px;
+}
+
+#toc {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 200px;
+    height: 100%;
+    overflow-y: auto;
+    background-color: #f4f4f4;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+#toc ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+pre {
+    background-color: #f4f4f4;
+    padding: 10px;
+    border: 1px solid #ddd;
+    overflow: auto;
+}
+
+code {
+    font-family: "Courier New", Courier, monospace;
+}

--- a/test.html
+++ b/test.html
@@ -4,33 +4,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Python Code Display</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 20px;
-        }
-        pre {
-            background-color: #f4f4f4;
-            padding: 10px;
-            border: 1px solid #ddd;
-            overflow: auto;
-        }
-        code {
-            font-family: "Courier New", Courier, monospace;
-        }
-    </style>
+    <link rel="stylesheet" href="style.css">
+    <script src="toc.js" defer></script>
 </head>
 <body>
-    <h1>Python Code: test.py</h1>
-    <pre><code>
-def test():
-    pass
-<!-- Add image from repository -->
-<img src="github_image.png" alt="Example Image">
-<!-- Add image from url hosted online -->
-<img src="https://example.com/path/to/image.jpg" alt="Example Image">
+    <nav id="toc"></nav>
+    <main>
+        <h1>Python Code: test.py</h1>
+        <pre><code>
+ def test():
+     pass
+ <!-- Add image from repository -->
+ <img src="github_image.png" alt="Example Image">
+ <!-- Add image from url hosted online -->
+ <img src="https://example.com/path/to/image.jpg" alt="Example Image">
 
-    </code></pre>
+        </code></pre>
+    </main>
 </body>
 </html>
-

--- a/toc.js
+++ b/toc.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', function() {
+    var toc = document.getElementById('toc');
+    if (!toc) return;
+
+    var headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    if (headers.length === 0) return;
+
+    var ul = toc.querySelector('ul');
+    if (!ul) {
+        ul = document.createElement('ul');
+        toc.appendChild(ul);
+    }
+
+    headers.forEach(function(header) {
+        if (!header.id) {
+            header.id = header.textContent.trim().toLowerCase().replace(/\s+/g, '-');
+        }
+        var li = document.createElement('li');
+        var a = document.createElement('a');
+        a.href = '#' + header.id;
+        a.textContent = header.textContent;
+        li.appendChild(a);
+        ul.appendChild(li);
+    });
+
+    toc.appendChild(ul);
+});


### PR DESCRIPTION
## Summary
- convert landing page to Markdown so README renders with custom sidebar
- add Home link in sidebar via `index.md`
- update `toc.js` to use existing list when building TOC

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6869eac0b214832aa3f0a8a0ef5b35ad